### PR TITLE
✨ [FEAT] VeginBtn 커스텀 클래스 생성

### DIFF
--- a/Vegin_iOS/Vegin_iOS.xcodeproj/project.pbxproj
+++ b/Vegin_iOS/Vegin_iOS.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		779015B92742E38300F83ACD /* WriteSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 779015B82742E38300F83ACD /* WriteSB.storyboard */; };
 		779015BB2742E51A00F83ACD /* WriteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779015BA2742E51A00F83ACD /* WriteVC.swift */; };
 		779015BD2743ACE800F83ACD /* CalendarNaviController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779015BC2743ACE800F83ACD /* CalendarNaviController.swift */; };
+		77DBB84627DB186100000623 /* VeginBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DBB84527DB186100000623 /* VeginBtn.swift */; };
 		77ED047727B691F800D077CA /* StoryboardRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ED047627B691F800D077CA /* StoryboardRepresentation.swift */; };
 		77ED047927B6927E00D077CA /* BaseNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ED047827B6927E00D077CA /* BaseNC.swift */; };
 		77ED047B27B692B500D077CA /* BaseTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ED047A27B692B500D077CA /* BaseTVC.swift */; };
@@ -96,6 +97,7 @@
 		779015B82742E38300F83ACD /* WriteSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WriteSB.storyboard; sourceTree = "<group>"; };
 		779015BA2742E51A00F83ACD /* WriteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteVC.swift; sourceTree = "<group>"; };
 		779015BC2743ACE800F83ACD /* CalendarNaviController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CalendarNaviController.swift; path = Vegin_iOS/Screen/Write/VC/CalendarNaviController.swift; sourceTree = SOURCE_ROOT; };
+		77DBB84527DB186100000623 /* VeginBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VeginBtn.swift; sourceTree = "<group>"; };
 		77ED047627B691F800D077CA /* StoryboardRepresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryboardRepresentation.swift; sourceTree = "<group>"; };
 		77ED047827B6927E00D077CA /* BaseNC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNC.swift; sourceTree = "<group>"; };
 		77ED047A27B692B500D077CA /* BaseTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTVC.swift; sourceTree = "<group>"; };
@@ -491,6 +493,7 @@
 			isa = PBXGroup;
 			children = (
 				77FE1733274B860C00F95F0D /* VeginAlertVC.swift */,
+				77DBB84527DB186100000623 /* VeginBtn.swift */,
 			);
 			path = Class;
 			sourceTree = "<group>";
@@ -681,6 +684,7 @@
 				772C1471273B7DAB00BB0127 /* SceneDelegate.swift in Sources */,
 				779015BB2742E51A00F83ACD /* WriteVC.swift in Sources */,
 				7757287827CD337D00148C9A /* DietListVC.swift in Sources */,
+				77DBB84627DB186100000623 /* VeginBtn.swift in Sources */,
 				77ED049527B6C8BA00D077CA /* Adjusted+.swift in Sources */,
 				77ED047927B6927E00D077CA /* BaseNC.swift in Sources */,
 				77ED047727B691F800D077CA /* StoryboardRepresentation.swift in Sources */,

--- a/Vegin_iOS/Vegin_iOS/Global/Extension/UIColor+.swift
+++ b/Vegin_iOS/Vegin_iOS/Global/Extension/UIColor+.swift
@@ -36,4 +36,12 @@ extension UIColor {
     @nonobjc class var gray0: UIColor {
         return UIColor(red: 156.0 / 255.0, green: 156.0 / 255.0, blue: 156.0 / 255.0, alpha: 1.0)
     }
+    
+    @nonobjc class var defaultGray: UIColor {
+        return UIColor(red: 237.0 / 255.0, green: 237.0 / 255.0, blue: 237.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var defaultTextGray: UIColor {
+        return UIColor(red: 168.0 / 255.0, green: 168.0 / 255.0, blue: 168.0 / 255.0, alpha: 1.0)
+    }
 }

--- a/Vegin_iOS/Vegin_iOS/Global/New Group/Xib/VeginAlertVC.xib
+++ b/Vegin_iOS/Vegin_iOS/Global/New Group/Xib/VeginAlertVC.xib
@@ -8,6 +8,11 @@
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Bold.otf">
+            <string>Pretendard-Bold</string>
+        </array>
+    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -32,18 +37,17 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3WF-EF-weH">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3WF-EF-weH" customClass="VeginBtn" customModule="Vegin_iOS" customModuleProvider="target">
                                 <rect key="frame" x="130.5" y="144" width="70" height="28"/>
                                 <color key="backgroundColor" name="darkMain"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="70" id="0ug-a3-Nqd"/>
                                     <constraint firstAttribute="height" constant="28" id="8YG-vC-P62"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="12"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="확인">
-                                    <fontDescription key="titleFontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="12"/>
-                                </buttonConfiguration>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="확인"/>
                                 <connections>
                                     <action selector="tapConfirmBtn:" destination="82P-Su-p00" eventType="touchUpInside" id="ceQ-n8-rx1"/>
                                 </connections>

--- a/Vegin_iOS/Vegin_iOS/Global/UIComponent/Class/VeginAlertVC.swift
+++ b/Vegin_iOS/Vegin_iOS/Global/UIComponent/Class/VeginAlertVC.swift
@@ -12,7 +12,7 @@ class VeginAlertVC: BaseVC {
     // MARK: Properties
     @IBOutlet weak var alertView: UIView!
     @IBOutlet weak var messageLabel: UILabel!
-    @IBOutlet weak var confirmBtn: UIButton!
+    @IBOutlet weak var confirmBtn: VeginBtn!
        
     // MARK: LifeCycle
     override func awakeFromNib() {
@@ -26,7 +26,7 @@ class VeginAlertVC: BaseVC {
     
     private func configureUI() {
         alertView.makeRounded(cornerRadius: 20.adjusted)
-        confirmBtn.makeRounded(cornerRadius: 0.5 * confirmBtn.bounds.size.height)
+        confirmBtn.isActivated = true
         messageLabel.setLineSpacing(lineSpacing: 5)
         messageLabel.textAlignment = .center
         self.modalPresentationStyle = .overFullScreen
@@ -35,6 +35,9 @@ class VeginAlertVC: BaseVC {
     
     func showVeginAlert(vc: UIViewController, message: String, confirmBtnTitle: String) {
         messageLabel.text = message
+        DispatchQueue.main.async {
+            self.confirmBtn.setTitleWithStyle(title: confirmBtnTitle, size: 12, weight: .bold)
+        }
         vc.present(self, animated: true, completion: nil)
     }
     

--- a/Vegin_iOS/Vegin_iOS/Global/UIComponent/Class/VeginBtn.swift
+++ b/Vegin_iOS/Vegin_iOS/Global/UIComponent/Class/VeginBtn.swift
@@ -1,0 +1,85 @@
+//
+//  VeginBtn.swift
+//  Vegin_iOS
+//
+//  Created by EUNJU on 2022/03/11.
+//
+
+import UIKit
+
+/**
+ - Description:
+ Vegin에서 자주 사용되는 bg: .darkMain / font: .white 컬러의 둥근 모양 버튼
+ 폰트는 Pretendard-SemiBold: 16pt가 기본이고 이외에는 메서드를 통해 커스텀하여 사용
+ 
+ - Note:
+ - setButton: 버튼 기본 셋팅 변경
+ - setTitle: 버튼 타이틀만 변경
+ - changeColors: 버튼 배경색, 글씨색 변경
+ */
+class VeginBtn: UIButton {
+    
+    // MARK: Properties
+    var isActivated: Bool = false {
+        didSet {
+            self.backgroundColor = self.isActivated ? activatedBgColor : normalBgColor
+            self.setTitleColor(self.isActivated ? activatedFontColor : normalFontColor, for: .normal)
+            self.isEnabled = isActivated
+        }
+    }
+    
+    private var normalBgColor: UIColor = .gray0
+    private var normalFontColor: UIColor = .white
+    private var activatedBgColor: UIColor = .darkMain
+    var activatedFontColor: UIColor = .white
+    
+    init() {
+        super.init(frame: .zero)
+        setDefaultStyle()
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)!
+        setDefaultStyle()
+    }
+    
+    // MARK: Private Methods
+    /// 디폴트 버튼 스타일 설정
+    private func setDefaultStyle() {
+        self.makeRounded(cornerRadius: 0.5 * self.bounds.size.height)
+        self.titleLabel?.font = .PretendardSB(size: 16)
+        self.backgroundColor = self.normalBgColor
+        self.tintColor = UIColor.gray0
+        self.setTitleColor(self.normalFontColor, for: .normal)
+    }
+    
+    // MARK: Public Methods
+    func setBtnColors(normalBgColor: UIColor, normalFontColor: UIColor, activatedBgColor: UIColor, activatedFontColor: UIColor) {
+        self.normalBgColor = normalBgColor
+        self.normalFontColor = normalFontColor
+        self.activatedBgColor = activatedBgColor
+        self.activatedFontColor = activatedFontColor
+    }
+    
+    /// 버튼 타이틀과 스타일 변경 폰트 사이즈 adjusted 적용
+    func setTitleWithStyle(title: String, size: CGFloat, weight: FontWeight = .regular) {
+        let font: UIFont
+        
+        switch weight {
+        case .light:
+            font = .PretendardL(size: size.adjusted)
+        case .regular:
+            font = .PretendardR(size: size.adjusted)
+        case .medium:
+            font = .PretendardM(size: size.adjusted)
+        case .bold:
+            font = .PretendardB(size: size.adjusted)
+        case .semiBold:
+            font = .PretendardSB(size: size.adjusted)
+        }
+        
+        self.titleLabel?.font = font
+        self.setTitle(title, for: .normal)
+    }
+}
+

--- a/Vegin_iOS/Vegin_iOS/Global/UIComponent/Class/VeginBtn.swift
+++ b/Vegin_iOS/Vegin_iOS/Global/UIComponent/Class/VeginBtn.swift
@@ -28,8 +28,8 @@ class VeginBtn: UIButton {
         }
     }
     
-    private var normalBgColor: UIColor = .gray0
-    private var normalFontColor: UIColor = .white
+    private var normalBgColor: UIColor = .defaultGray
+    private var normalFontColor: UIColor = .defaultTextGray
     private var activatedBgColor: UIColor = .darkMain
     var activatedFontColor: UIColor = .white
     
@@ -49,7 +49,7 @@ class VeginBtn: UIButton {
         self.makeRounded(cornerRadius: 0.5 * self.bounds.size.height)
         self.titleLabel?.font = .PretendardSB(size: 16)
         self.backgroundColor = self.normalBgColor
-        self.tintColor = UIColor.gray0
+        self.tintColor = UIColor.white
         self.setTitleColor(self.normalFontColor, for: .normal)
     }
     

--- a/Vegin_iOS/Vegin_iOS/Screen/Write/SB/WriteSB.storyboard
+++ b/Vegin_iOS/Vegin_iOS/Screen/Write/SB/WriteSB.storyboard
@@ -3,7 +3,6 @@
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -317,18 +316,15 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5gg-1V-ZjI">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5gg-1V-ZjI" customClass="VeginBtn" customModule="Vegin_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="37" y="794" width="300" height="40"/>
-                                                <color key="backgroundColor" name="darkMain"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="UEL-HB-OCf"/>
                                                     <constraint firstAttribute="width" constant="300" id="YLQ-Qp-xDc"/>
                                                 </constraints>
-                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="저장하기">
-                                                    <fontDescription key="titleFontDescription" name="Pretendard-Bold" family="Pretendard" pointSize="12"/>
-                                                </buttonConfiguration>
                                                 <connections>
                                                     <action selector="touchUpToSaveButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="vL4-h2-7Xw"/>
                                                 </connections>
@@ -467,9 +463,6 @@
         <image name="medium" width="47" height="36"/>
         <image name="milk" width="42" height="42"/>
         <image name="much" width="47" height="36"/>
-        <namedColor name="darkMain">
-            <color red="0.32156862745098042" green="0.59999999999999998" blue="0.35294117647058826" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Vegin_iOS/Vegin_iOS/Screen/Write/VC/WriteVC.swift
+++ b/Vegin_iOS/Vegin_iOS/Screen/Write/VC/WriteVC.swift
@@ -63,7 +63,12 @@ class WriteVC: BaseVC, UINavigationControllerDelegate, UIImagePickerControllerDe
     @IBOutlet weak var imageUploadButton: UIButton!
     @IBOutlet var mealButtons: [UIButton]!
     @IBOutlet var amountButtons: [UIButton]!
-    @IBOutlet weak var saveBtn: UIButton!
+    @IBOutlet weak var saveBtn: VeginBtn! {
+        didSet {
+            saveBtn.isActivated = false
+            saveBtn.setTitleWithStyle(title: "저장하기", size: 16, weight: .semiBold)
+        }
+    }
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -106,7 +111,6 @@ class WriteVC: BaseVC, UINavigationControllerDelegate, UIImagePickerControllerDe
 
         calendarEmoji.updateValue(resultEmoji, forKey: "\(getDayDate(date: Date()))")
         UserDefaults.standard.set(calendarEmoji, forKey: "calendarEmoji")
-        //UserDefaults.standard.removeObject(forKey: "calendarEmoji")
         print(UserDefaults.standard.dictionary(forKey: "calendarEmoji"))
         
         guard let alert = Bundle.main.loadNibNamed(VeginAlertVC.className, owner: self, options: nil)?.first as? VeginAlertVC else { return }
@@ -114,9 +118,6 @@ class WriteVC: BaseVC, UINavigationControllerDelegate, UIImagePickerControllerDe
         alert.confirmBtn.press {
             self.navigationController?.popViewController(animated: true)
         }
-//        print(emojiArray)
-//        print(resultEmoji)
-        
     }
     
     func setIconImage() {
@@ -156,7 +157,7 @@ class WriteVC: BaseVC, UINavigationControllerDelegate, UIImagePickerControllerDe
         } else if !isLevel6Selected {
             level6Button.setImage(UIImage.init(named: "meat"), for: .normal)
         }
-
+        setUpSaveBtnStatus()
     }
     
     @IBAction func touchUpLevel1Btn(_ sender: Any) {
@@ -195,6 +196,7 @@ class WriteVC: BaseVC, UINavigationControllerDelegate, UIImagePickerControllerDe
             sender.isSelected = true
             indexOfMeal = mealButtons.firstIndex(of: sender)
         }
+        setUpSaveBtnStatus()
     }
     
     @IBAction func touchUpAmountButton(_ sender: UIButton) {
@@ -213,6 +215,7 @@ class WriteVC: BaseVC, UINavigationControllerDelegate, UIImagePickerControllerDe
             sender.isSelected = true
             indexOfAmount = amountButtons.firstIndex(of: sender)
         }
+        setUpSaveBtnStatus()
     }
     @IBAction func touchUpToShowImage(_ sender: Any) {
         let alert = UIAlertController(title: "이미지 업로드", message: "식단 사진을 업로드해주세요", preferredStyle: .actionSheet)
@@ -265,8 +268,10 @@ class WriteVC: BaseVC, UINavigationControllerDelegate, UIImagePickerControllerDe
         imageUploadButton.tintColor = .clear
         dismiss(animated: true, completion: nil)
     }
-    
-    
+}
+
+// MARK: - UI
+extension WriteVC {
     private func configureUI() {
         picker.delegate = self
         memoTextView.delegate = self
@@ -305,6 +310,24 @@ class WriteVC: BaseVC, UINavigationControllerDelegate, UIImagePickerControllerDe
     }
 }
 
+// MARK: - Custom Methods
+extension WriteVC {
+    
+    /// 저장하기 버튼 상태 지정 메소드
+    private func setUpSaveBtnStatus() {
+        if isLevel1Selected || isLevel2Selected || isLevel3Selected || isLevel4Selected || isLevel5Selected || isLevel6Selected {
+            if indexOfMeal != nil && indexOfAmount != nil {
+                self.saveBtn.isActivated = true
+            } else {
+                self.saveBtn.isActivated = false
+            }
+        } else {
+            self.saveBtn.isActivated = false
+        }
+    }
+}
+
+// MARK: - UITextViewDelegate
 extension WriteVC: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.text == placeholder {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #29 

## 🍎 변경 사항 및 이유
- `VeginBtn` 커스텀 클래스 생성
- 식단 기록 뷰 저장하기 버튼 비활성화 판단 코드 추가

## 🍎 PR Point
**[적용방법]**

<img width="440" alt="스크린샷 2022-03-13 오후 7 40 16" src="https://user-images.githubusercontent.com/63277563/158055711-aee00b79-ff82-4281-a8ba-756b5d67b7ea.png">

`button` 의 커스텀 클래스를 VeginBtn으로 지정합니다.
그 후 아래와 같이 원하는 버튼의 상태를 지정하고 메소드를 통해 커스텀해줍니다.

~~~Swift
saveBtn.isActivated = false
saveBtn.setTitleWithStyle(title: "저장하기", size: 16, weight: .semiBold)
~~~

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/158055654-4e4cae97-33e3-4054-972c-452ee1ca8793.mp4


